### PR TITLE
Fix app title

### DIFF
--- a/apps/todos-frontend/src/app/app.spec.tsx
+++ b/apps/todos-frontend/src/app/app.spec.tsx
@@ -10,6 +10,6 @@ describe('App', () => {
 
   it('should have a greeting as the title', () => {
     const { getByText } = render(<App />);
-    expect(getByText('Todo--s App')).toBeTruthy();
+    expect(getByText('Todos App')).toBeTruthy();
   });
 });

--- a/apps/todos-frontend/src/app/app.tsx
+++ b/apps/todos-frontend/src/app/app.tsx
@@ -93,7 +93,7 @@ const App: React.FC = () => {
   return (
     <div className="min-h-screen bg-gray-100 p-6">
       <div className="max-w-4xl mx-auto bg-white shadow-lg rounded-lg p-6">
-        <h1 className="text-2xl font-bold text-center mb-4">Todo--s App</h1>
+        <h1 className="text-2xl font-bold text-center mb-4">Todos App</h1>
 
         <div className="flex gap-2 mb-6">
           <input


### PR DESCRIPTION
## Summary
- fix double hyphen typo in the page title
- update unit test

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_683fa22579748321ba0548d1a00df68c