### PR TITLE
Reorder preloaded task e2e check

### DIFF
--- a/apps/todos-frontend-e2e/src/todo.spec.ts
+++ b/apps/todos-frontend-e2e/src/todo.spec.ts
@@ -1,19 +1,52 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Todo App', () => {
-  test('should add a task and verify it appears in the list', async ({
-    page,
-  }) => {
-    // Navigate to the app
+  test('should display pre-loaded tasks on page load', async ({ page }) => {
     await page.goto('http://localhost:4200');
 
-    // Add a new task
-    const taskName = 'New Task Here';
-    await page.fill('input[placeholder="Enter task name"]', taskName); // Adjust selector based on your app
-    await page.click('button >> text=Add Task'); // Adjust text based on your app
+    const firstTask = page.locator('ul li').first();
+    await expect(firstTask).not.toHaveText('No tasks available.');
+  });
 
-    // Wait for the new task to appear in the list
+  test('should add a task and verify it appears in the list', async ({ page }) => {
+    await page.goto('http://localhost:4200');
+
+    const taskName = 'New Task Here';
+    await page.fill('input[placeholder="Enter task name"]', taskName);
+    await page.getByRole('button', { name: 'Add Task' }).click();
+
     const taskLocator = page.locator(`text=${taskName}`).first();
     await expect(taskLocator).toBeVisible();
+  });
+
+  test('should mark a task as completed', async ({ page }) => {
+    await page.goto('http://localhost:4200');
+
+    const taskName = 'Task to Complete';
+    await page.fill('input[placeholder="Enter task name"]', taskName);
+    await page.getByRole('button', { name: 'Add Task' }).click();
+
+    const taskItem = page.locator('li', { hasText: taskName }).first();
+    await expect(taskItem).toBeVisible();
+
+    const completeButton = taskItem.getByRole('button', { name: 'Complete' });
+    await completeButton.click();
+    await expect(completeButton).toBeDisabled();
+  });
+
+  test('should delete a task from the list', async ({ page }) => {
+    await page.goto('http://localhost:4200');
+
+    const taskName = 'Task to Delete';
+    await page.fill('input[placeholder="Enter task name"]', taskName);
+    await page.getByRole('button', { name: 'Add Task' }).click();
+
+    const taskItem = page.locator('li', { hasText: taskName }).first();
+    await expect(taskItem).toBeVisible();
+
+    const deleteButton = taskItem.getByRole('button', { name: 'Delete' });
+    await deleteButton.click();
+
+    await expect(taskItem).not.toBeVisible();
   });
 });

--- a/apps/todos-frontend-e2e/src/todo.spec.ts
+++ b/apps/todos-frontend-e2e/src/todo.spec.ts
@@ -31,7 +31,7 @@ test.describe('Todo App', () => {
 
     const completeButton = taskItem.getByRole('button', { name: 'Complete' });
     await completeButton.click();
-    await expect(completeButton).toBeDisabled({ timeout: 10000 });
+    await expect(completeButton).toBeDisabled({ timeout: 15000 });
   });
 
   test('should delete a task from the list', async ({ page }) => {
@@ -47,6 +47,6 @@ test.describe('Todo App', () => {
     const deleteButton = taskItem.getByRole('button', { name: 'Delete' });
     await deleteButton.click();
 
-    await expect(taskItem).not.toBeVisible({ timeout: 10000 });
+    await expect(taskItem).not.toBeVisible({ timeout: 15000 });
   });
 });

--- a/apps/todos-frontend-e2e/src/todo.spec.ts
+++ b/apps/todos-frontend-e2e/src/todo.spec.ts
@@ -31,7 +31,7 @@ test.describe('Todo App', () => {
 
     const completeButton = taskItem.getByRole('button', { name: 'Complete' });
     await completeButton.click();
-    await expect(completeButton).toBeDisabled();
+    await expect(completeButton).toBeDisabled({ timeout: 10000 });
   });
 
   test('should delete a task from the list', async ({ page }) => {
@@ -47,6 +47,6 @@ test.describe('Todo App', () => {
     const deleteButton = taskItem.getByRole('button', { name: 'Delete' });
     await deleteButton.click();
 
-    await expect(taskItem).not.toBeVisible();
+    await expect(taskItem).not.toBeVisible({ timeout: 10000 });
   });
 });

--- a/apps/todos-frontend/src/app/app.spec.tsx
+++ b/apps/todos-frontend/src/app/app.spec.tsx
@@ -1,4 +1,7 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import axios from 'axios';
+
+jest.mock('axios');
 
 import App from './app';
 
@@ -11,5 +14,20 @@ describe('App', () => {
   it('should have a greeting as the title', () => {
     const { getByText } = render(<App />);
     expect(getByText('Todos App')).toBeTruthy();
+  });
+
+  it('should render the task input and add button', () => {
+    (axios.get as jest.Mock).mockResolvedValue({ data: [] });
+    render(<App />);
+
+    expect(screen.getByPlaceholderText('Enter task name')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Add Task' })).toBeTruthy();
+  });
+
+  it('should show message when no tasks are available', async () => {
+    (axios.get as jest.Mock).mockResolvedValue({ data: [] });
+    render(<App />);
+
+    expect(await screen.findByText('No tasks available.')).toBeTruthy();
   });
 });

--- a/apps/todos-frontend/src/app/app.spec.tsx
+++ b/apps/todos-frontend/src/app/app.spec.tsx
@@ -1,9 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import axios from 'axios';
+import App from './app';
 
 jest.mock('axios');
-
-import App from './app';
 
 describe('App', () => {
   it('should render successfully', () => {


### PR DESCRIPTION
## Summary
- run e2e browser install and test
- move the pre-loaded tasks verification test to the top of `todo.spec.ts`

## Testing
- `yarn test`
- `yarn e2e` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_683fff2d4e488321832f96026bd697a3